### PR TITLE
Allow manual seed for Zipfian distribution generation

### DIFF
--- a/include/tests/ZipfianTest.hpp
+++ b/include/tests/ZipfianTest.hpp
@@ -9,7 +9,7 @@ namespace kmercounter {
 
 class ZipfianTest {
  public:
-  void run(Shard *sh, BaseHashTable *kmer_ht, double skew, uint64_t seed, unsigned int count, std::barrier<std::function<void ()>>*);
+  void run(Shard *sh, BaseHashTable *kmer_ht, double skew, int64_t seed, unsigned int count, std::barrier<std::function<void ()>>*);
 };
 
 }  // namespace kmercounter

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -115,6 +115,8 @@ struct Configuration {
 
   // controls zipfian dist
   double skew;
+  // seed for zipf dist generation
+  int64_t seed;
   // R/W ratio for associated tests (modes 12 and 8)
   double pread;
   // used for kmer parsing from disk
@@ -150,7 +152,7 @@ struct Configuration {
     printf("  ht_size %" PRIu64 " (%" PRIu64 " GiB)\n", ht_size, ht_size/(1ul << 30));
     printf("BQUEUES:\n  n_prod %u | n_cons %u\n", n_prod, n_cons);
     printf("  ht_fill %u\n", ht_fill);
-    printf("ZIPFIAN:\n  skew: %f\n", skew);
+    printf("ZIPFIAN:\n  skew: %f\n  seed: %ld\n", skew, seed);
     printf("  HW prefetchers %s\n", hwprefetchers ? "enabled" : "disabled");
     printf("  SW prefetch engine %s\n", no_prefetch ? "disabled" : "enabled");
     printf("  Run both %s\n", run_both ? "enabled" : "disabled");

--- a/include/zipf_distribution.hpp
+++ b/include/zipf_distribution.hpp
@@ -31,7 +31,7 @@ namespace kmercounter {
 
 class zipf_distribution_apache {
 public:
-  zipf_distribution_apache(uint64_t num_elements, double exponent, uint64_t seed);
+  zipf_distribution_apache(uint64_t num_elements, double exponent, int64_t seed);
   uint64_t sample();
 private:
   static constexpr double TAYLOR_THRESHOLD = 1e-8;

--- a/src/tests/hashtable_tests.cpp
+++ b/src/tests/hashtable_tests.cpp
@@ -33,9 +33,9 @@ bool stop_sync = false;
 
 extern std::vector<std::uint64_t, huge_page_allocator<uint64_t>> *zipf_values;
 
-OpTimings do_zipfian_inserts(BaseHashTable *hashtable, double skew,
+OpTimings do_zipfian_inserts(BaseHashTable *hashtable, double skew, int64_t seed,
                              unsigned int count, unsigned int id,
-                             std::barrier<std::function<void()>> *sync_barrier, uint64_t seed) {
+                             std::barrier<std::function<void()>> *sync_barrier) {
   auto keyrange_width = (1ull << 63);
   zipf_distribution_apache distribution(keyrange_width, skew, seed);
 
@@ -193,7 +193,7 @@ OpTimings do_zipfian_gets(BaseHashTable *hashtable, unsigned int num_threads,
   return {duration, found};
 }
 
-void ZipfianTest::run(Shard *shard, BaseHashTable *hashtable, double skew, uint64_t zipf_seed,
+void ZipfianTest::run(Shard *shard, BaseHashTable *hashtable, double skew, int64_t zipf_seed,
                       unsigned int count, std::barrier<std::function<void ()>> *sync_barrier) {
   OpTimings insert_timings{};
   static_assert(HT_TESTS_MAX_STRIDE - 1 ==
@@ -217,7 +217,7 @@ void ZipfianTest::run(Shard *shard, BaseHashTable *hashtable, double skew, uint6
 
   for (uint32_t i = 1; i < HT_TESTS_MAX_STRIDE; i++) {
     insert_timings =
-        do_zipfian_inserts(hashtable, skew, count, shard->shard_idx, sync_barrier, zipf_seed);
+        do_zipfian_inserts(hashtable, skew, zipf_seed, count, shard->shard_idx, sync_barrier);
     PLOG_INFO.printf(
         "Quick stats: thread %u, Batch size: %d, cycles per "
         "insertion:%" PRIu64 "",

--- a/src/tests/queue_tests.cpp
+++ b/src/tests/queue_tests.cpp
@@ -68,25 +68,18 @@ __attribute__((
 
 std::vector<std::uint64_t, huge_page_allocator<uint64_t>> *zipf_values;
 
-void init_zipfian_dist(double skew, uint64_t seed) {
+void init_zipfian_dist(double skew, int64_t seed) {
   constexpr auto keyrange_width = (1ull << 63);
 
   zipf_values = new std::vector<uint64_t, huge_page_allocator<uint64_t>>(
       HT_TESTS_NUM_INSERTS);
   zipf_distribution_apache distribution(keyrange_width, skew, seed);
-  PLOGI.printf("Initializing global zipf with skew %f, seed %d", skew, seed);
+  PLOGI.printf("Initializing global zipf with skew %f, seed %ld", skew, seed);
 
   for (auto &value : *zipf_values) {
     value = distribution.sample();
   }
   PLOGI.printf("Zipfian dist generated. size %zu", zipf_values->size());
-
-  int n_sanity_check_vals = zipf_values->size() >= 10 ? 10 : zipf_values->size();
-  PLOGI.printf("First %d generated Zipfian dist values:", n_sanity_check_vals);
-
-  for (int i = 0; i < n_sanity_check_vals; ++i) {
-    PLOGI.printf("Zipfian value %d: %d", i, zipf_values->at(i));
-  }
 }
 
 inline std::tuple<double, uint64_t, uint64_t> get_params(uint32_t n_prod,

--- a/src/zipf_distribution.cpp
+++ b/src/zipf_distribution.cpp
@@ -30,13 +30,13 @@
 
 namespace kmercounter {
 
-zipf_distribution_apache::zipf_distribution_apache(uint64_t num_elements, double exponent, uint64_t seed):
+zipf_distribution_apache::zipf_distribution_apache(uint64_t num_elements, double exponent, int64_t seed):
 num_elements(num_elements),
 exponent(exponent),
 h_integral_x1(h_integral(1.5) - 1),
 h_integral_num_elements(h_integral(num_elements + F_1_2)),
 s(2 - h_integral_inverse(h_integral(2.5) - h(2))),
-generator(seed), // std::chrono::system_clock::now().time_since_epoch().count()
+generator(seed),
 distribution(0, 1)
 {
   if (exponent <= 0) throw std::invalid_argument("exponent must be positive");


### PR DESCRIPTION
Adds actual logic to override the seed in zipf generation, and provides a CLI option to provide a seed manually. If no seed is provided, it defaults to the old way of generating a seed based on the clock.

To make sure this works, I ran it several times with manual seed `123456` and made sure the config dump showed that seed, and that the distribution was consistent each time by printing the first 10 values, which ended up being `[23144448, -1852534784, 686223616, -2132613632, -712498176, -347028480, 1548844032, -81139200, -1123383296, 330908672]`

I also ran it several times without providing a manual seed and made sure the config dump showed different seeds and distributions (first 10 values) each time.